### PR TITLE
seccomp_bpf_tests: add support for proposed TSYNC behavior

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -f $(EXEC)
 
 seccomp_bpf_tests: seccomp_bpf_tests.c test_harness.h
-	$(CC) seccomp_bpf_tests.c -o seccomp_bpf_tests $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+	$(CC) seccomp_bpf_tests.c -o seccomp_bpf_tests $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -pthread
 
 resumption: resumption.c test_harness.h
 	$(CC) $^ -o $@ $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -ggdb3


### PR DESCRIPTION
Add support for the proposed cross-thread synchronization
functionality.  If implemented as proposed, it will provide
a means for a thread group to synchronize on a given seccomp
filter after thread creation as long as only the caller has
attached new filters (and any eligible threads are under seccomp
mode=2)

(Issuing as a pull request to allow easy commenting)
