### PR TITLE
tests: invoke time vsyscall directly

### DIFF
--- a/tests/resumption.c
+++ b/tests/resumption.c
@@ -67,13 +67,8 @@ static void syscall_thunk(void)
 	asm("syscall; thunk_ip:");
 }
 
-static time_t vsyscall_time(time_t *p)
-{
-	register time_t t asm ("rax");
-	__attribute__((unused)) register time_t *p1 asm ("rdi") = p;
-	__asm__("call 0xffffffffff600400 \n");
-	return t;
-}
+typedef time_t (*vsys_time_t)(time_t *);
+static const vsys_time_t vsyscall_time = (vsys_time_t)0xffffffffff600400;
 
 
 #if 0


### PR DESCRIPTION
The invocation of the time vsyscall produces a segfault when
built using a toolchain that produces position independent
executables by default. This is because the inline asm produces
an RIP-relative call whose offset does not get adjusted by the
dynamic linker.

Fix this by eliminating the vsyscall wrapper and defining
vsyscall_time to be a pointer to the fixed vsyscall address.

Signed-off-by: Seth Forshee <seth.forshee@canonical.com>